### PR TITLE
Make env.render() show observation before the first step.

### DIFF
--- a/gym_snake/envs/snake_env.py
+++ b/gym_snake/envs/snake_env.py
@@ -39,10 +39,9 @@ class SnakeEnv(gym.Env):
             self.viewer = self.fig.add_subplot(111)
             plt.ion()
             self.fig.show()
-        else:
-            self.viewer.clear()
-            self.viewer.imshow(self.last_obs)
-            plt.pause(frame_speed)
+        self.viewer.clear()
+        self.viewer.imshow(self.last_obs)
+        plt.pause(frame_speed)
         self.fig.canvas.draw()
 
     def seed(self, x):


### PR DESCRIPTION
env.render() inside python notebook doesn't take an effect before the first step. That PR fixes this bug